### PR TITLE
[GSK-4159] Fix handling of error in ModelOutput

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -767,6 +767,17 @@ test = ["flufl.flake8", "importlib-resources (>=1.3)", "jaraco.test (>=5.4)", "p
 type = ["pytest-mypy"]
 
 [[package]]
+name = "iniconfig"
+version = "2.0.0"
+description = "brain-dead simple config-ini parsing"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "iniconfig-2.0.0-py3-none-any.whl", hash = "sha256:b6a85871a79d2e3b22d2d1b94ac2824226a63c6b741c88f7ae975f18b6778374"},
+    {file = "iniconfig-2.0.0.tar.gz", hash = "sha256:2d91e135bf72d31a410b17c16da610a82cb55f6b0477d1a902134b24a455b8b3"},
+]
+
+[[package]]
 name = "ipykernel"
 version = "6.29.5"
 description = "IPython Kernel for Jupyter"
@@ -1616,6 +1627,21 @@ test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.3.2)", "pytest-
 type = ["mypy (>=1.11.2)"]
 
 [[package]]
+name = "pluggy"
+version = "1.5.0"
+description = "plugin and hook calling mechanisms for python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pluggy-1.5.0-py3-none-any.whl", hash = "sha256:44e1ad92c8ca002de6377e165f3e0f1be63266ab4d554740532335b9d75ea669"},
+    {file = "pluggy-1.5.0.tar.gz", hash = "sha256:2cffa88e94fdc978c4c574f15f9e59b7f4201d439195c3715ca9e2486f1d0cf1"},
+]
+
+[package.extras]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
+
+[[package]]
 name = "prometheus-client"
 version = "0.21.1"
 description = "Python client for the Prometheus monitoring system."
@@ -1752,6 +1778,28 @@ typing-extensions = {version = ">=3.10.0", markers = "python_version < \"3.10\""
 [package.extras]
 spelling = ["pyenchant (>=3.2,<4.0)"]
 testutils = ["gitpython (>3)"]
+
+[[package]]
+name = "pytest"
+version = "8.3.4"
+description = "pytest: simple powerful testing with Python"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
+    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+exceptiongroup = {version = ">=1.0.0rc8", markers = "python_version < \"3.11\""}
+iniconfig = "*"
+packaging = "*"
+pluggy = ">=1.5,<2"
+tomli = {version = ">=1", markers = "python_version < \"3.11\""}
+
+[package.extras]
+dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
 name = "python-dateutil"
@@ -3020,4 +3068,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.9,<4.0"
-content-hash = "61898a779517eaeb38fa9b1567a295c8596d313445a5072e89ff19269b9b14d9"
+content-hash = "07d319609ea817861434dd9ac58dee5d1c43bc281bd7a435fb4b87bf21c40238"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "giskard-hub"
 version = "1.1.0"
 description = "The giskard_hub library allows you to interact with the Giskard Hub, a platform that centralizes the validation process of LLM applications, empowering product teams to ensure all functional, business & legal requirements are met, and keeping them in close contact with the development team to avoid delayed deployment timelines."
-authors = ["Bazire <bazire@giskard.ai>", "Henrique Chaves <henrique@giskard.ai>"]
+authors = ["Giskard Team <hello@giskard.ai>"]
 readme = "README.md"
 packages = [{ include = "giskard_hub", from = "src" }]
 repository = "https://github.com/Giskard-AI/giskard-hub"
@@ -28,6 +28,7 @@ sphinx-click = "^6.0.0"
 sphinx-autobuild = "^2024.4.16"
 sphinx-autodoc-typehints = "^2.1.1"
 sphinx-design = "^0.6.0"
+pytest = "^8.3.4"
 
 [build-system]
 requires = ["poetry-core"]

--- a/src/giskard_hub/data/evaluation.py
+++ b/src/giskard_hub/data/evaluation.py
@@ -184,9 +184,15 @@ class EvaluationEntry(Entity):
 
     @classmethod
     def from_dict(cls, data: Dict[str, Any], **kwargs) -> "EvaluationEntry":
+        data = dict(data)
         data["conversation"] = Conversation.from_dict(data["conversation"])
         output = data.get("output")
         data["model_output"] = ModelOutput.from_dict(output) if output else None
+
+        run_id = data.get("evaluation_run_id") or data.get("execution_id")
+        if run_id:
+            data["run_id"] = run_id
+
         return super().from_dict(data, **kwargs)
 
 

--- a/src/giskard_hub/data/model.py
+++ b/src/giskard_hub/data/model.py
@@ -9,18 +9,29 @@ from .chat import ChatMessage
 
 
 @dataclass
+class ExecutionError(BaseData):
+    """Model error."""
+
+    message: str
+    details: Dict[str, any] = field(default_factory=dict)
+
+
+@dataclass
 class ModelOutput(BaseData):
     """Model output."""
 
-    message: ChatMessage
+    message: ChatMessage | None = None
     metadata: Dict[str, any] = field(default_factory=dict)
+    error: ExecutionError | None = None
 
     @classmethod
     def from_dict(cls, data: Dict[str, any], **kwargs) -> "BaseData":
         msg = data.get("response") or data.get("message")
+        error = data.get("error")
         return cls(
-            message=ChatMessage.from_dict(msg),
+            message=ChatMessage.from_dict(msg) if msg else None,
             metadata=data.get("metadata", {}),
+            error=ExecutionError.from_dict(error) if error else None,
         )
 
 

--- a/tests/test_model_output.py
+++ b/tests/test_model_output.py
@@ -1,0 +1,42 @@
+from giskard_hub.data.model import ModelOutput
+
+
+def test_model_output_can_instantiate_from_dict():
+    # With message
+    data = {
+        "response": {
+            "role": "user",
+            "content": "Hello, how are you?",
+        },
+        "metadata": {"key": "value"},
+    }
+    model_output = ModelOutput.from_dict(data)
+    assert model_output.message.content == "Hello, how are you?"
+    assert model_output.error is None
+    assert model_output.metadata == {"key": "value"}
+
+    # With error
+    data = {
+        "metadata": {"meta1": "value1"},
+        "error": {
+            "message": "Error",
+            "details": {"key": "value"},
+        },
+    }
+    model_output = ModelOutput.from_dict(data)
+    assert model_output.message is None
+    assert model_output.error.message == "Error"
+    assert model_output.error.details == {"key": "value"}
+    assert model_output.metadata == {"meta1": "value1"}
+
+    # Without metadata
+    data = {
+        "response": {
+            "role": "user",
+            "content": "Hello, how are you?",
+        },
+    }
+    model_output = ModelOutput.from_dict(data)
+    assert model_output.message.content == "Hello, how are you?"
+    assert model_output.error is None
+    assert model_output.metadata == {}


### PR DESCRIPTION
There was a bug in handling `ModelOutput` when the response message is absent because of an execution error on the model API.