### PR TITLE
chore(api): [GSK-4308] Rename any Conversation mention to ChatTestCase

### DIFF
--- a/src/giskard_hub/__init__.py
+++ b/src/giskard_hub/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .client import HubClient
 from .data import Dataset, Model, Project
 from .data.chat import ChatMessage
+from .data.chat_test_case import ChatTestCase
 from .data.conversation import Conversation
 
 hub_url: str | None = None
@@ -11,6 +12,7 @@ api_key: str | None = None
 
 __all__ = [
     "Dataset",
+    "ChatTestCase",
     "Conversation",
     "ChatMessage",
     "Project",

--- a/src/giskard_hub/client.py
+++ b/src/giskard_hub/client.py
@@ -19,6 +19,8 @@ from .resources.models import ModelsResource
 from .resources.projects import ProjectsResource
 
 
+# pylint: disable=too-many-instance-attributes
+# The `conversations` resource is deprecated and will be removed in the future.
 class HubClient(SyncClient):
     """Client class to handle interaction with the hub.
 

--- a/src/giskard_hub/client.py
+++ b/src/giskard_hub/client.py
@@ -11,6 +11,7 @@ from .data.chat import ChatMessage
 from .data.dataset import Dataset
 from .data.model import Model, ModelOutput
 from .errors import HubConnectionError
+from .resources.chat_test_cases import ChatTestCasesResource
 from .resources.conversations import ConversationsResource
 from .resources.datasets import DatasetsResource
 from .resources.evaluations import EvaluationsResource
@@ -29,6 +30,9 @@ class HubClient(SyncClient):
     datasets : DatasetsResource
         Resource to interact with datasets.
 
+    chat_test_cases : ChatTestCasesResource
+        Resource to interact with chat test cases.
+
     conversations : ConversationsResource
         Resource to interact with conversations.
 
@@ -44,6 +48,7 @@ class HubClient(SyncClient):
 
     projects: ProjectsResource
     datasets: DatasetsResource
+    chat_test_cases: ChatTestCasesResource
     conversations: ConversationsResource
     models: ModelsResource
     evaluations: EvaluationsResource
@@ -120,6 +125,7 @@ class HubClient(SyncClient):
         # Define the resources
         self.projects = ProjectsResource(self)
         self.datasets = DatasetsResource(self)
+        self.chat_test_cases = ChatTestCasesResource(self)
         self.conversations = ConversationsResource(self)
         self.models = ModelsResource(self)
         self.evaluations = EvaluationsResource(self)
@@ -149,7 +155,7 @@ class HubClient(SyncClient):
         dataset : str | Dataset
             ID of the dataset that will be used for the evaluation, or the dataset entity.
         tags: List[str], optional
-            List of tags to filter the conversations that will be evaluated.
+            List of tags to filter the conversations (chat test cases) that will be evaluated.
         model : str | Model | Callable[[List[ChatMessage]], ModelOutput | str]
             ID of the model to evaluate, or a model entity, or a local model function.
             A local model function is a function that takes a list of messages and returns a `ModelOutput` or a string.

--- a/src/giskard_hub/data/__init__.py
+++ b/src/giskard_hub/data/__init__.py
@@ -1,4 +1,5 @@
 from .chat import ChatMessage
+from .chat_test_case import ChatTestCase
 from .conversation import Conversation
 from .dataset import Dataset
 from .evaluation import EvaluationRun, Metric, ModelOutput
@@ -9,6 +10,7 @@ __all__ = [
     "Project",
     "Dataset",
     "Conversation",
+    "ChatTestCase",
     "ChatMessage",
     "Model",
     "ModelOutput",

--- a/src/giskard_hub/data/chat_test_case.py
+++ b/src/giskard_hub/data/chat_test_case.py
@@ -1,43 +1,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
-from giskard_hub.data.check import CheckConfig, TestCaseCheckConfig
+from giskard_hub.data.check import CheckConfig, _format_checks_to_cli
 
 from ._entity import Entity
 from .chat import ChatMessage, ChatMessageWithMetadata
-
-
-def _format_checks_to_cli(
-    checks: List[Union[TestCaseCheckConfig, Dict[str, Any]]],
-) -> List[CheckConfig]:
-    if not checks:
-        return []
-
-    checks = [check if isinstance(check, dict) else check.to_dict() for check in checks]
-
-    return [
-        CheckConfig.from_dict(
-            {
-                "identifier": check["identifier"],
-                "enabled": check["enabled"],
-                **(
-                    {"params": params}
-                    if check.get("assertions")
-                    and (
-                        params := {
-                            k: v
-                            for k, v in check["assertions"][0].items()
-                            if k != "type"
-                        }
-                    )
-                    else {}
-                ),
-            }
-        )
-        for check in checks
-    ]
 
 
 @dataclass
@@ -52,7 +21,7 @@ class ChatTestCase(Entity):
         Output of the agent for demonstration purposes.
     tags : List[str], optional
         List of tags for the chat test case.
-    checks : List[TestCaseCheckConfig], optional
+    checks : List[CheckConfig], optional
         List of checks to be performed on the chat test case.
     """
 

--- a/src/giskard_hub/data/chat_test_case.py
+++ b/src/giskard_hub/data/chat_test_case.py
@@ -74,7 +74,6 @@ class ChatTestCase(Entity):
             demo_output = ChatMessageWithMetadata.from_dict(data["demo_output"])
 
         # Process checks
-        # FIXME: This should be done with TestCaseCheckConfig
         checks = _format_checks_to_cli(data.get("checks", []))
 
         # Create the object with processed data

--- a/src/giskard_hub/data/chat_test_case.py
+++ b/src/giskard_hub/data/chat_test_case.py
@@ -74,6 +74,7 @@ class ChatTestCase(Entity):
             demo_output = ChatMessageWithMetadata.from_dict(data["demo_output"])
 
         # Process checks
+        # FIXME: This should be done with TestCaseCheckConfig
         checks = _format_checks_to_cli(data.get("checks", []))
 
         # Create the object with processed data

--- a/src/giskard_hub/data/chat_test_case.py
+++ b/src/giskard_hub/data/chat_test_case.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from ._base import BaseData
+from ._entity import Entity
+from .chat import ChatMessage, ChatMessageWithMetadata
+
+
+def _format_checks_to_cli(checks: List[TestCaseCheckConfig]) -> List[CheckConfig]:
+    return [
+        {
+            "identifier": check["identifier"],
+            "enabled": check["enabled"],
+            **(
+                {"params": params}
+                if check.get("assertions")
+                and (
+                    params := {
+                        k: v for k, v in check["assertions"][0].items() if k != "type"
+                    }
+                )
+                else {}
+            ),
+        }
+        for check in checks
+    ]
+
+
+@dataclass
+class CheckConfig(BaseData):
+    identifier: str
+    params: Optional[dict[str, Any]] = None
+
+
+@dataclass
+class TestCaseCheckConfig(BaseData):
+    identifier: str
+    assertions: List[dict[str, Any]]
+
+
+@dataclass
+class ChatTestCase(Entity):
+    """A Dataset entry representing a chat test case.
+
+    Attributes
+    ----------
+    messages : List[ChatMessage]
+        List of messages in the chat test case. Each message is an object with a role and content attributes.
+    demo_output : Optional[ChatMessageWithMetadata], optional
+        Output of the agent for demonstration purposes.
+    tags : List[str], optional
+        List of tags for the chat test case.
+    checks : List[TestCaseCheckConfig], optional
+        List of checks to be performed on the chat test case.
+    """
+
+    messages: List[ChatMessage] = field(default_factory=list)
+    demo_output: Optional[ChatMessageWithMetadata] = field(default=None)
+    tags: List[str] = field(default_factory=list)
+    checks: List[TestCaseCheckConfig] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any], **kwargs) -> "ChatTestCase":
+        # Process messages
+        messages = []
+        if data.get("messages"):
+            messages = [ChatMessage.from_dict(msg) for msg in data["messages"]]
+
+        # Process demo_output
+        demo_output = None
+        if data.get("demo_output"):
+            demo_output = ChatMessageWithMetadata.from_dict(data["demo_output"])
+
+        # Process checks
+        checks = _format_checks_to_cli(data.get("checks", []))
+
+        # Create the object with processed data
+        obj = super().from_dict(
+            {
+                **data,
+                "messages": messages,
+                "demo_output": demo_output,
+                "checks": checks,
+            },
+            **kwargs,
+        )
+
+        return obj

--- a/src/giskard_hub/data/check.py
+++ b/src/giskard_hub/data/check.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from ._base import BaseData
 
@@ -18,3 +18,58 @@ class CheckConfig(BaseData):
     identifier: str
     params: Optional[Dict[str, Any]] = None
     enabled: bool = True
+
+
+def _format_checks_to_backend(
+    checks: List[Union[CheckConfig, Dict[str, Any]]],
+) -> List[TestCaseCheckConfig]:
+    if not checks:
+        return []
+
+    checks = [check if isinstance(check, dict) else check.to_dict() for check in checks]
+
+    return [
+        TestCaseCheckConfig.from_dict(
+            {
+                "enabled": True,  # Default value for enabled
+                **check,
+                **(
+                    {"assertions": [{"type": check["identifier"], **check["params"]}]}
+                    if check.get("params")
+                    else {}
+                ),
+            }
+        )
+        for check in checks
+    ]
+
+
+def _format_checks_to_cli(
+    checks: List[Union[TestCaseCheckConfig, Dict[str, Any]]],
+) -> List[CheckConfig]:
+    if not checks:
+        return []
+
+    checks = [check if isinstance(check, dict) else check.to_dict() for check in checks]
+
+    return [
+        CheckConfig.from_dict(
+            {
+                "identifier": check["identifier"],
+                "enabled": check["enabled"],
+                **(
+                    {"params": params}
+                    if check.get("assertions")
+                    and (
+                        params := {
+                            k: v
+                            for k, v in check["assertions"][0].items()
+                            if k != "type"
+                        }
+                    )
+                    else {}
+                ),
+            }
+        )
+        for check in checks
+    ]

--- a/src/giskard_hub/data/check.py
+++ b/src/giskard_hub/data/check.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional
 
 from ._base import BaseData
 
@@ -18,58 +18,3 @@ class CheckConfig(BaseData):
     identifier: str
     params: Optional[Dict[str, Any]] = None
     enabled: bool = True
-
-
-def _format_checks_to_cli(
-    checks: List[Union[TestCaseCheckConfig, Dict[str, Any]]],
-) -> List[CheckConfig]:
-    if not checks:
-        return []
-
-    checks = [check if isinstance(check, dict) else check.to_dict() for check in checks]
-
-    return [
-        CheckConfig.from_dict(
-            {
-                "identifier": check["identifier"],
-                "enabled": check["enabled"],
-                **(
-                    {"params": params}
-                    if check.get("assertions")
-                    and (
-                        params := {
-                            k: v
-                            for k, v in check["assertions"][0].items()
-                            if k != "type"
-                        }
-                    )
-                    else {}
-                ),
-            }
-        )
-        for check in checks
-    ]
-
-
-def _format_checks_to_backend(
-    checks: List[Union[CheckConfig, Dict[str, Any]]],
-) -> List[TestCaseCheckConfig]:
-    if not checks:
-        return []
-
-    checks = [check if isinstance(check, dict) else check.to_dict() for check in checks]
-
-    return [
-        TestCaseCheckConfig.from_dict(
-            {
-                "enabled": True,  # Default value for enabled
-                **check,
-                **(
-                    {"assertions": [{"type": check["identifier"], **check["params"]}]}
-                    if check.get("params")
-                    else {}
-                ),
-            }
-        )
-        for check in checks
-    ]

--- a/src/giskard_hub/data/conversation.py
+++ b/src/giskard_hub/data/conversation.py
@@ -1,47 +1,14 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+import warnings
+from dataclasses import dataclass
+from typing import Any, Dict
 
-from ._base import BaseData
-from ._entity import Entity
-from .chat import ChatMessage, ChatMessageWithMetadata
-
-
-def _format_checks_to_cli(checks: List[TestCaseCheckConfig]) -> List[CheckConfig]:
-    return [
-        {
-            "identifier": check["identifier"],
-            "enabled": check["enabled"],
-            **(
-                {"params": params}
-                if check.get("assertions")
-                and (
-                    params := {
-                        k: v for k, v in check["assertions"][0].items() if k != "type"
-                    }
-                )
-                else {}
-            ),
-        }
-        for check in checks
-    ]
+from .chat_test_case import ChatTestCase
 
 
 @dataclass
-class CheckConfig(BaseData):
-    identifier: str
-    params: Optional[dict[str, Any]] = None
-
-
-@dataclass
-class TestCaseCheckConfig(BaseData):
-    identifier: str
-    assertions: List[dict[str, Any]]
-
-
-@dataclass
-class Conversation(Entity):
+class Conversation(ChatTestCase):
     """A Dataset entry representing a conversation.
 
     Attributes
@@ -56,35 +23,10 @@ class Conversation(Entity):
         List of checks to be performed on the conversation.
     """
 
-    messages: List[ChatMessage] = field(default_factory=list)
-    demo_output: Optional[ChatMessageWithMetadata] = field(default=None)
-    tags: List[str] = field(default_factory=list)
-    checks: List[TestCaseCheckConfig] = field(default_factory=list)
-
     @classmethod
     def from_dict(cls, data: Dict[str, Any], **kwargs) -> "Conversation":
-        # Process messages
-        messages = []
-        if data.get("messages"):
-            messages = [ChatMessage.from_dict(msg) for msg in data["messages"]]
-
-        # Process demo_output
-        demo_output = None
-        if data.get("demo_output"):
-            demo_output = ChatMessageWithMetadata.from_dict(data["demo_output"])
-
-        # Process checks
-        checks = _format_checks_to_cli(data.get("checks", []))
-
-        # Create the object with processed data
-        obj = super().from_dict(
-            {
-                **data,
-                "messages": messages,
-                "demo_output": demo_output,
-                "checks": checks,
-            },
-            **kwargs,
+        warnings.warn(
+            "Conversation is deprecated and will be removed. Please use ChatTestCase instead.",
+            category=DeprecationWarning,
         )
-
-        return obj
+        return super().from_dict(data, **kwargs)

--- a/src/giskard_hub/data/dataset.py
+++ b/src/giskard_hub/data/dataset.py
@@ -44,6 +44,7 @@ class Dataset(Entity):
             dataset_id=self.id, **conversation.to_dict()
         )
 
+    @property
     def chat_test_cases(self):
         """Return the chat test cases of the dataset."""
         if self._client and self.id:

--- a/src/giskard_hub/data/dataset.py
+++ b/src/giskard_hub/data/dataset.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass, field
 from typing import List, Optional
 
 from ._entity import Entity
+from .chat_test_case import ChatTestCase
 from .conversation import Conversation
 
 
@@ -19,12 +21,20 @@ class Dataset(Entity):
     @property
     def conversations(self):
         """Return the conversations of the dataset."""
+        warnings.warn(
+            "Conversation is deprecated and will be removed. Please use ChatTestCase operations instead.",
+            category=DeprecationWarning,
+        )
         if self._client and self.id:
             return self._client.conversations.list(dataset_id=self.id)
         return None
 
     def create_conversation(self, conversation: Conversation):
         """Add a conversation to the dataset."""
+        warnings.warn(
+            "Conversation is deprecated and will be removed. Please use ChatTestCase operations instead.",
+            category=DeprecationWarning,
+        )
         if not self._client or not self.id:
             raise ValueError(
                 "This dataset instance is detached or unsaved, cannot add conversation."
@@ -32,4 +42,21 @@ class Dataset(Entity):
 
         return self._client.conversations.create(
             dataset_id=self.id, **conversation.to_dict()
+        )
+
+    def chat_test_cases(self):
+        """Return the chat test cases of the dataset."""
+        if self._client and self.id:
+            return self._client.chat_test_cases.list(dataset_id=self.id)
+        return None
+
+    def create_chat_test_case(self, chat_test_case: ChatTestCase):
+        """Add a chat test case to the dataset."""
+        if not self._client or not self.id:
+            raise ValueError(
+                "This dataset instance is detached or unsaved, cannot add chat test case."
+            )
+
+        return self._client.chat_test_cases.create(
+            dataset_id=self.id, **chat_test_case.to_dict()
         )

--- a/src/giskard_hub/data/evaluation.py
+++ b/src/giskard_hub/data/evaluation.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import math
 import time
-import warnings
 from dataclasses import dataclass, field
 from time import sleep
 from typing import Any, Dict, List

--- a/src/giskard_hub/data/evaluation.py
+++ b/src/giskard_hub/data/evaluation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import time
+import warnings
 from dataclasses import dataclass, field
 from time import sleep
 from typing import Any, Dict, List
@@ -11,6 +12,7 @@ from rich.table import Table
 
 from ._base import BaseData
 from ._entity import Entity
+from .chat_test_case import ChatTestCase
 from .conversation import Conversation
 from .dataset import Dataset
 from .model import Model, ModelOutput
@@ -178,7 +180,7 @@ class EvaluationEntry(Entity):
     """Evaluation entry."""
 
     run_id: str
-    conversation: Conversation
+    conversation: Conversation | ChatTestCase
     model_output: ModelOutput | None = None
     results: List[EvaluatorResult] = field(default_factory=list)
     status: TaskStatus = TaskStatus.RUNNING
@@ -186,7 +188,12 @@ class EvaluationEntry(Entity):
     @classmethod
     def from_dict(cls, data: Dict[str, Any], **kwargs) -> "EvaluationEntry":
         data = dict(data)
-        data["conversation"] = Conversation.from_dict(data["conversation"])
+
+        if "chat_test_case" in data:
+            data["conversation"] = ChatTestCase.from_dict(data["chat_test_case"])
+        else:
+            data["conversation"] = Conversation.from_dict(data["conversation"])
+
         output = data.get("output")
         data["model_output"] = ModelOutput.from_dict(output) if output else None
 

--- a/src/giskard_hub/resources/__init__.py
+++ b/src/giskard_hub/resources/__init__.py
@@ -1,3 +1,4 @@
+from .chat_test_cases import ChatTestCasesResource
 from .conversations import ConversationsResource
 from .datasets import DatasetsResource
 from .evaluations import EvaluationsResource
@@ -7,6 +8,7 @@ from .projects import ProjectsResource
 __all__ = [
     "ProjectsResource",
     "DatasetsResource",
+    "ChatTestCasesResource",
     "ConversationsResource",
     "ModelsResource",
     "EvaluationsResource",

--- a/src/giskard_hub/resources/_utils.py
+++ b/src/giskard_hub/resources/_utils.py
@@ -1,8 +1,10 @@
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional
+
+from giskard_hub.data.check import _format_checks_to_backend
 
 from ..data._base import NOT_GIVEN, filter_not_given, maybe_to_dict
 from ..data.chat import ChatMessage, ChatMessageWithMetadata
-from ..data.chat_test_case import CheckConfig, TestCaseCheckConfig
+from ..data.chat_test_case import CheckConfig
 
 
 def prepare_chat_test_case_data(
@@ -28,27 +30,3 @@ def prepare_chat_test_case_data(
             ],
         }
     )
-
-
-def _format_checks_to_backend(
-    checks: List[Union[CheckConfig, Dict[str, Any]]],
-) -> List[TestCaseCheckConfig]:
-    if not checks:
-        return []
-
-    checks = [check if isinstance(check, dict) else check.to_dict() for check in checks]
-
-    return [
-        TestCaseCheckConfig.from_dict(
-            {
-                "enabled": True,  # Default value for enabled
-                **check,
-                **(
-                    {"assertions": [{"type": check["identifier"], **check["params"]}]}
-                    if check.get("params")
-                    else {}
-                ),
-            }
-        )
-        for check in checks
-    ]

--- a/src/giskard_hub/resources/_utils.py
+++ b/src/giskard_hub/resources/_utils.py
@@ -1,0 +1,42 @@
+from typing import Any, List, Optional
+
+from ..data._base import NOT_GIVEN, filter_not_given, maybe_to_dict
+from ..data.chat import ChatMessage, ChatMessageWithMetadata
+from ..data.chat_test_case import CheckConfig, TestCaseCheckConfig
+
+
+def prepare_chat_test_case_data(
+    dataset_id: str,
+    messages: List[ChatMessage],
+    demo_output: Optional[ChatMessageWithMetadata] = NOT_GIVEN,
+    tags: Optional[List[str]] = None,
+    checks: Optional[List[CheckConfig]] = None,
+) -> dict[str, Any]:
+    """Prepare the data for creating or updating a chat test case."""
+    if tags is None:
+        tags = []
+    if checks is None:
+        checks = []
+    return filter_not_given(
+        {
+            "dataset_id": dataset_id,
+            "messages": [maybe_to_dict(msg) for msg in messages],
+            "demo_output": maybe_to_dict(demo_output),
+            "tags": tags,
+            "checks": _format_checks_to_backend(checks),
+        }
+    )
+
+
+def _format_checks_to_backend(checks: list[CheckConfig]) -> list[TestCaseCheckConfig]:
+    return [
+        {
+            **check,
+            **(
+                {"assertions": [{"type": check["identifier"], **check["params"]}]}
+                if check.get("params")
+                else {}
+            ),
+        }
+        for check in checks
+    ]

--- a/src/giskard_hub/resources/_utils.py
+++ b/src/giskard_hub/resources/_utils.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from ..data._base import NOT_GIVEN, filter_not_given, maybe_to_dict
 from ..data.chat import ChatMessage, ChatMessageWithMetadata
@@ -30,15 +30,25 @@ def prepare_chat_test_case_data(
     )
 
 
-def _format_checks_to_backend(checks: list[CheckConfig]) -> list[TestCaseCheckConfig]:
+def _format_checks_to_backend(
+    checks: List[Union[CheckConfig, Dict[str, Any]]],
+) -> List[TestCaseCheckConfig]:
+    if not checks:
+        return []
+
+    checks = [check if isinstance(check, dict) else check.to_dict() for check in checks]
+
     return [
-        {
-            **check,
-            **(
-                {"assertions": [{"type": check["identifier"], **check["params"]}]}
-                if check.get("params")
-                else {}
-            ),
-        }
+        TestCaseCheckConfig.from_dict(
+            {
+                "enabled": True,  # Default value for enabled
+                **check,
+                **(
+                    {"assertions": [{"type": check["identifier"], **check["params"]}]}
+                    if check.get("params")
+                    else {}
+                ),
+            }
+        )
         for check in checks
     ]

--- a/src/giskard_hub/resources/chat_test_cases.py
+++ b/src/giskard_hub/resources/chat_test_cases.py
@@ -70,7 +70,7 @@ class ChatTestCasesResource(APIResource):
         )
 
     def list(self, dataset_id: str) -> List[ChatTestCase]:
-        data = self._client.get(f"/datasets/{dataset_id}/chat_test_cases?limit=100000")
+        data = self._client.get(f"/datasets/{dataset_id}/chat-test-cases?limit=100000")
         return [
             ChatTestCase.from_dict(d, _client=self._client)
             for d in data.get("items", [])

--- a/src/giskard_hub/resources/chat_test_cases.py
+++ b/src/giskard_hub/resources/chat_test_cases.py
@@ -1,26 +1,12 @@
 from __future__ import annotations
 
-import warnings
 from typing import List, Optional
 
-from ..data._base import NOT_GIVEN, filter_not_given, maybe_to_dict
+from ..data._base import NOT_GIVEN
 from ..data.chat import ChatMessage, ChatMessageWithMetadata
-from ..data.chat_test_case import ChatTestCase, CheckConfig, TestCaseCheckConfig
+from ..data.chat_test_case import ChatTestCase, CheckConfig
 from ._resource import APIResource
-
-
-def _format_checks_to_backend(checks: list[CheckConfig]) -> list[TestCaseCheckConfig]:
-    return [
-        {
-            **check,
-            **(
-                {"assertions": [{"type": check["identifier"], **check["params"]}]}
-                if check.get("params")
-                else {}
-            ),
-        }
-        for check in checks
-    ]
+from ._utils import prepare_chat_test_case_data
 
 
 class ChatTestCasesResource(APIResource):
@@ -39,18 +25,12 @@ class ChatTestCasesResource(APIResource):
         tags: Optional[List[str]] = None,
         checks: Optional[List[CheckConfig]] = None,
     ):
-        if tags is None:
-            tags = []
-        if checks is None:
-            checks = []
-        data = filter_not_given(
-            {
-                "dataset_id": dataset_id,
-                "messages": [maybe_to_dict(msg) for msg in messages],
-                "demo_output": maybe_to_dict(demo_output),
-                "tags": tags,
-                "checks": _format_checks_to_backend(checks),
-            }
+        data = prepare_chat_test_case_data(
+            dataset_id=dataset_id,
+            messages=messages,
+            demo_output=demo_output,
+            tags=tags,
+            checks=checks,
         )
 
         return self._client.post(
@@ -70,16 +50,12 @@ class ChatTestCasesResource(APIResource):
         tags: Optional[List[str]] = NOT_GIVEN,
         checks: Optional[List[CheckConfig]] = NOT_GIVEN,
     ) -> ChatTestCase:
-        data = filter_not_given(
-            {
-                "dataset_id": dataset_id,
-                "messages": (
-                    [maybe_to_dict(msg) for msg in messages] if messages else messages
-                ),
-                "demo_output": maybe_to_dict(demo_output),
-                "tags": tags,
-                "checks": _format_checks_to_backend(checks) if checks else checks,
-            }
+        data = prepare_chat_test_case_data(
+            dataset_id=dataset_id,
+            messages=messages,
+            demo_output=demo_output,
+            tags=tags,
+            checks=checks,
         )
 
         return self._client.patch(

--- a/src/giskard_hub/resources/chat_test_cases.py
+++ b/src/giskard_hub/resources/chat_test_cases.py
@@ -66,7 +66,7 @@ class ChatTestCasesResource(APIResource):
 
     def delete(self, chat_test_case_id: str | List[str]) -> None:
         return self._client.delete(
-            "/chat_test_cases", params={"chat_test_case_ids": chat_test_case_id}
+            "/chat-test-cases", params={"chat_test_case_ids": chat_test_case_id}
         )
 
     def list(self, dataset_id: str) -> List[ChatTestCase]:

--- a/src/giskard_hub/resources/chat_test_cases.py
+++ b/src/giskard_hub/resources/chat_test_cases.py
@@ -12,7 +12,7 @@ from ._utils import prepare_chat_test_case_data
 class ChatTestCasesResource(APIResource):
     def retrieve(self, chat_test_case_id: str):
         return self._client.get(
-            f"/chat_test_cases/{chat_test_case_id}", cast_to=ChatTestCase
+            f"/chat-test-cases/{chat_test_case_id}", cast_to=ChatTestCase
         )
 
     # pylint: disable=too-many-arguments

--- a/src/giskard_hub/resources/chat_test_cases.py
+++ b/src/giskard_hub/resources/chat_test_cases.py
@@ -5,11 +5,8 @@ from typing import List, Optional
 
 from ..data._base import NOT_GIVEN, filter_not_given, maybe_to_dict
 from ..data.chat import ChatMessage, ChatMessageWithMetadata
-from ..data.chat_test_case import CheckConfig, TestCaseCheckConfig
-from ..data.conversation import Conversation
+from ..data.chat_test_case import ChatTestCase, CheckConfig, TestCaseCheckConfig
 from ._resource import APIResource
-
-_CONVERSATION_DEPRECATION_WARNING = "Conversation API is deprecated and will be removed. Please use ChatTestCase API instead."
 
 
 def _format_checks_to_backend(checks: list[CheckConfig]) -> list[TestCaseCheckConfig]:
@@ -26,14 +23,10 @@ def _format_checks_to_backend(checks: list[CheckConfig]) -> list[TestCaseCheckCo
     ]
 
 
-class ConversationsResource(APIResource):
-    def retrieve(self, conversation_id: str):
-        warnings.warn(
-            _CONVERSATION_DEPRECATION_WARNING,
-            category=DeprecationWarning,
-        )
+class ChatTestCasesResource(APIResource):
+    def retrieve(self, chat_test_case_id: str):
         return self._client.get(
-            f"/conversations/{conversation_id}", cast_to=Conversation
+            f"/chat_test_cases/{chat_test_case_id}", cast_to=ChatTestCase
         )
 
     # pylint: disable=too-many-arguments
@@ -46,10 +39,6 @@ class ConversationsResource(APIResource):
         tags: Optional[List[str]] = None,
         checks: Optional[List[CheckConfig]] = None,
     ):
-        warnings.warn(
-            _CONVERSATION_DEPRECATION_WARNING,
-            category=DeprecationWarning,
-        )
         if tags is None:
             tags = []
         if checks is None:
@@ -65,26 +54,22 @@ class ConversationsResource(APIResource):
         )
 
         return self._client.post(
-            "/conversations",
+            "/chat_test_cases",
             json=data,
-            cast_to=Conversation,
+            cast_to=ChatTestCase,
         )
 
     # pylint: disable=too-many-arguments
     def update(
         self,
-        conversation_id: str,
+        chat_test_case_id: str,
         *,
         dataset_id: str = NOT_GIVEN,
         messages: List[ChatMessage] = NOT_GIVEN,
         demo_output: Optional[ChatMessageWithMetadata] = NOT_GIVEN,
         tags: Optional[List[str]] = NOT_GIVEN,
         checks: Optional[List[CheckConfig]] = NOT_GIVEN,
-    ) -> Conversation:
-        warnings.warn(
-            _CONVERSATION_DEPRECATION_WARNING,
-            category=DeprecationWarning,
-        )
+    ) -> ChatTestCase:
         data = filter_not_given(
             {
                 "dataset_id": dataset_id,
@@ -98,27 +83,19 @@ class ConversationsResource(APIResource):
         )
 
         return self._client.patch(
-            f"/conversations/{conversation_id}",
+            f"/chat_test_cases/{chat_test_case_id}",
             json=data,
-            cast_to=Conversation,
+            cast_to=ChatTestCase,
         )
 
-    def delete(self, conversation_id: str | List[str]) -> None:
-        warnings.warn(
-            _CONVERSATION_DEPRECATION_WARNING,
-            category=DeprecationWarning,
-        )
+    def delete(self, chat_test_case_id: str | List[str]) -> None:
         return self._client.delete(
-            "/conversations", params={"conversation_ids": conversation_id}
+            "/chat_test_cases", params={"chat_test_case_ids": chat_test_case_id}
         )
 
-    def list(self, dataset_id: str) -> List[Conversation]:
-        warnings.warn(
-            _CONVERSATION_DEPRECATION_WARNING,
-            category=DeprecationWarning,
-        )
-        data = self._client.get(f"/datasets/{dataset_id}/conversations?limit=100000")
+    def list(self, dataset_id: str) -> List[ChatTestCase]:
+        data = self._client.get(f"/datasets/{dataset_id}/chat_test_cases?limit=100000")
         return [
-            Conversation.from_dict(d, _client=self._client)
+            ChatTestCase.from_dict(d, _client=self._client)
             for d in data.get("items", [])
         ]

--- a/src/giskard_hub/resources/chat_test_cases.py
+++ b/src/giskard_hub/resources/chat_test_cases.py
@@ -59,7 +59,7 @@ class ChatTestCasesResource(APIResource):
         )
 
         return self._client.patch(
-            f"/chat_test_cases/{chat_test_case_id}",
+            f"/chat-test-cases/{chat_test_case_id}",
             json=data,
             cast_to=ChatTestCase,
         )

--- a/src/giskard_hub/resources/chat_test_cases.py
+++ b/src/giskard_hub/resources/chat_test_cases.py
@@ -34,7 +34,7 @@ class ChatTestCasesResource(APIResource):
         )
 
         return self._client.post(
-            "/chat_test_cases",
+            "/chat-test-cases",
             json=data,
             cast_to=ChatTestCase,
         )

--- a/src/giskard_hub/resources/conversations.py
+++ b/src/giskard_hub/resources/conversations.py
@@ -37,6 +37,8 @@ class ConversationsResource(APIResource):
             _CONVERSATION_DEPRECATION_WARNING,
             category=DeprecationWarning,
         )
+        # pylint: disable=similarities
+        # The `conversations` resource is deprecated and will be removed in the future.
         data = prepare_conversation_data(
             dataset_id=dataset_id,
             messages=messages,
@@ -66,6 +68,8 @@ class ConversationsResource(APIResource):
             _CONVERSATION_DEPRECATION_WARNING,
             category=DeprecationWarning,
         )
+        # pylint: disable=similarities
+        # The `conversations` resource is deprecated and will be removed in the future.
         data = prepare_conversation_data(
             dataset_id=dataset_id,
             messages=messages,

--- a/src/giskard_hub/resources/conversations.py
+++ b/src/giskard_hub/resources/conversations.py
@@ -3,27 +3,14 @@ from __future__ import annotations
 import warnings
 from typing import List, Optional
 
-from ..data._base import NOT_GIVEN, filter_not_given, maybe_to_dict
+from ..data._base import NOT_GIVEN
 from ..data.chat import ChatMessage, ChatMessageWithMetadata
-from ..data.chat_test_case import CheckConfig, TestCaseCheckConfig
+from ..data.chat_test_case import CheckConfig
 from ..data.conversation import Conversation
 from ._resource import APIResource
+from ._utils import prepare_chat_test_case_data as prepare_conversation_data
 
 _CONVERSATION_DEPRECATION_WARNING = "Conversation API is deprecated and will be removed. Please use ChatTestCase API instead."
-
-
-def _format_checks_to_backend(checks: list[CheckConfig]) -> list[TestCaseCheckConfig]:
-    return [
-        {
-            **check,
-            **(
-                {"assertions": [{"type": check["identifier"], **check["params"]}]}
-                if check.get("params")
-                else {}
-            ),
-        }
-        for check in checks
-    ]
 
 
 class ConversationsResource(APIResource):
@@ -50,18 +37,12 @@ class ConversationsResource(APIResource):
             _CONVERSATION_DEPRECATION_WARNING,
             category=DeprecationWarning,
         )
-        if tags is None:
-            tags = []
-        if checks is None:
-            checks = []
-        data = filter_not_given(
-            {
-                "dataset_id": dataset_id,
-                "messages": [maybe_to_dict(msg) for msg in messages],
-                "demo_output": maybe_to_dict(demo_output),
-                "tags": tags,
-                "checks": _format_checks_to_backend(checks),
-            }
+        data = prepare_conversation_data(
+            dataset_id=dataset_id,
+            messages=messages,
+            demo_output=demo_output,
+            tags=tags,
+            checks=checks,
         )
 
         return self._client.post(
@@ -85,16 +66,12 @@ class ConversationsResource(APIResource):
             _CONVERSATION_DEPRECATION_WARNING,
             category=DeprecationWarning,
         )
-        data = filter_not_given(
-            {
-                "dataset_id": dataset_id,
-                "messages": (
-                    [maybe_to_dict(msg) for msg in messages] if messages else messages
-                ),
-                "demo_output": maybe_to_dict(demo_output),
-                "tags": tags,
-                "checks": _format_checks_to_backend(checks) if checks else checks,
-            }
+        data = prepare_conversation_data(
+            dataset_id=dataset_id,
+            messages=messages,
+            demo_output=demo_output,
+            tags=tags,
+            checks=checks,
         )
 
         return self._client.patch(

--- a/src/giskard_hub/resources/conversations.py
+++ b/src/giskard_hub/resources/conversations.py
@@ -5,7 +5,7 @@ from typing import List, Optional
 
 from ..data._base import NOT_GIVEN
 from ..data.chat import ChatMessage, ChatMessageWithMetadata
-from ..data.check import CheckConfig, _format_checks_to_backend
+from ..data.check import CheckConfig
 from ..data.conversation import Conversation
 from ._resource import APIResource
 from ._utils import prepare_chat_test_case_data as prepare_conversation_data

--- a/tests/test_chat_test_cases.py
+++ b/tests/test_chat_test_cases.py
@@ -1,0 +1,68 @@
+from giskard_hub.data.chat_test_case import ChatTestCase
+from giskard_hub.data.conversation import Conversation
+
+
+def test_consistency_between_conversations_and_chat_test_cases():
+    dto = {
+        "id": "conv_123",
+        "dataset_id": "ds_456",
+        "messages": [
+            {
+                "role": "user",
+                "content": "Hello, how are you?",
+            },
+            {
+                "role": "assistant",
+                "content": "I'm fine, thank you!",
+            },
+        ],
+        "demo_output": {
+            "role": "assistant",
+            "content": "I'm here to help you.",
+            "metadata": {"source": "demo"},
+        },
+        "tags": ["greeting", "test"],
+        "checks": [],
+    }
+
+    conversation = Conversation.from_dict(dto)
+    chat_test_case = ChatTestCase.from_dict(dto)
+
+    # Check messages
+    assert len(chat_test_case.messages) == len(conversation.messages)
+    for i in range(len(chat_test_case.messages)):
+        assert chat_test_case.messages[i].role == conversation.messages[i].role
+        assert chat_test_case.messages[i].content == conversation.messages[i].content
+
+    # Check demo_output
+    assert chat_test_case.demo_output.role == conversation.demo_output.role
+    assert chat_test_case.demo_output.content == conversation.demo_output.content
+    assert chat_test_case.demo_output.metadata == conversation.demo_output.metadata
+    assert len(chat_test_case.demo_output.metadata) == len(
+        conversation.demo_output.metadata
+    )
+    for key in chat_test_case.demo_output.metadata:
+        assert key in conversation.demo_output.metadata
+        assert (
+            chat_test_case.demo_output.metadata[key]
+            == conversation.demo_output.metadata[key]
+        )
+
+    # Check tags
+    assert len(chat_test_case.tags) == len(conversation.tags)
+    for tag in chat_test_case.tags:
+        assert tag in conversation.tags
+
+    # Check checks
+    assert chat_test_case.checks == conversation.checks
+    assert len(chat_test_case.checks) == len(conversation.checks)
+    for i in range(len(chat_test_case.checks)):
+        assert chat_test_case.checks[i].identifier == conversation.checks[i].identifier
+        assert len(chat_test_case.checks[i].assertions) == len(
+            conversation.checks[i].assertions
+        )
+
+    # Check common attributes
+    assert chat_test_case.id == conversation.id
+    assert chat_test_case.created_at == conversation.created_at
+    assert chat_test_case.updated_at == conversation.updated_at

--- a/tests/test_evaluations.py
+++ b/tests/test_evaluations.py
@@ -1,0 +1,56 @@
+from giskard_hub.data.chat_test_case import ChatTestCase
+from giskard_hub.data.conversation import Conversation
+from giskard_hub.data.evaluation import EvaluationEntry
+from giskard_hub.data.task import TaskStatus
+
+TEST_CONVERSATION_DATA = {
+    "id": "conv_123",
+    "dataset_id": "ds_456",
+    "messages": [
+        {"role": "user", "content": "Hello!"},
+        {"role": "assistant", "content": "Hi there! How can I help you?"},
+    ],
+    "demo_output": {
+        "role": "assistant",
+        "content": "This is a demo output.",
+        "metadata": {"key": "value"},
+    },
+    "tags": ["greeting", "test"],
+    "checks": [],
+}
+
+
+def test_evaluation_entry_from_chat_test_case():
+    chat_test_case_data = TEST_CONVERSATION_DATA.copy()
+
+    chat_test_case = ChatTestCase.from_dict(chat_test_case_data)
+    evaluation_entry = EvaluationEntry.from_dict(
+        {
+            "chat_test_case": chat_test_case_data,
+            "run_id": "run_123",
+            "results": [],
+            "status": TaskStatus.RUNNING,
+            "model_output": None,
+        }
+    )
+
+    assert isinstance(evaluation_entry.conversation, ChatTestCase)
+    assert evaluation_entry.conversation.id == chat_test_case.id
+
+
+def test_evaluation_entry_from_conversation():
+    conversation_data = TEST_CONVERSATION_DATA.copy()
+
+    conversation = Conversation.from_dict(conversation_data)
+    evaluation_entry = EvaluationEntry.from_dict(
+        {
+            "conversation": conversation_data,
+            "run_id": "run_123",
+            "results": [],
+            "status": TaskStatus.RUNNING,
+            "model_output": None,
+        }
+    )
+
+    assert isinstance(evaluation_entry.conversation, Conversation)
+    assert evaluation_entry.conversation.id == conversation.id


### PR DESCRIPTION
Main points:

- add `ChatTestCasesResource` and `ChatTestCase` data class
- mark conversation usage as deprecated with warnings
- get `chat_test_case` or `conversation` from the evaluation results to ensure compatibility