### PR TITLE
fix: [GSK-4424] return checks with type in params when retrieving conversation

### DIFF
--- a/src/giskard_hub/data/check.py
+++ b/src/giskard_hub/data/check.py
@@ -53,15 +53,8 @@ def _format_checks_to_backend(
     ]
 
 
-def extract_check_params(
-    check: Dict[str, Any], without_type: bool = False
-) -> Dict[str, Any]:
-    check_params = check["assertions"][0] if check.get("assertions") else {}
-
-    if without_type and ("type" in check_params):
-        check_params.pop("type")
-
-    return check_params
+def extract_check_params(check: Dict[str, Any]) -> Dict[str, Any]:
+    return check["assertions"][0] if check.get("assertions") else {}
 
 
 def _format_checks_to_cli(
@@ -77,7 +70,7 @@ def _format_checks_to_cli(
             {
                 "identifier": check["identifier"],
                 "enabled": check["enabled"],
-                "params": extract_check_params(check, without_type=True),
+                "params": extract_check_params(check),
             }
         )
         for check in checks

--- a/tests/test_conversations.py
+++ b/tests/test_conversations.py
@@ -161,11 +161,15 @@ def test_conversation_create(mock_client):
     assert len(result.checks) == 2
     assert result.checks[0].identifier == "correctness"
     assert result.checks[0].enabled
-    assert result.checks[0].params == {"reference": "I'll help you track your order."}
+    assert result.checks[0].params == {
+        "reference": "I'll help you track your order.",
+        "type": "correctness",
+    }
     assert result.checks[1].identifier == "conformity"
     assert result.checks[1].enabled
     assert result.checks[1].params == {
-        "rules": ["The assistant should be helpful and polite."]
+        "rules": ["The assistant should be helpful and polite."],
+        "type": "conformity",
     }
     assert "comments" not in result.to_dict()
 
@@ -322,7 +326,10 @@ def test_conversation_update(mock_client):
     assert result.messages[0].content == "Updated content!"
     assert "updated-tag" in result.tags
     assert result.checks[0].identifier == "correctness"
-    assert result.checks[0].params == {"reference": "Updated reference"}
+    assert result.checks[0].params == {
+        "reference": "Updated reference",
+        "type": "correctness",
+    }
     assert result.checks[0].enabled
     assert "comments" not in result.to_dict()
 
@@ -393,7 +400,10 @@ def test_conversation_from_dict():
     assert conversation.demo_output.metadata == {"intent": "greeting"}
     assert "test-tag" in conversation.tags
     assert conversation.checks[0].identifier == "correctness"
-    assert conversation.checks[0].params == {"reference": "Hello world"}
+    assert conversation.checks[0].params == {
+        "reference": "Hello world",
+        "type": "correctness",
+    }
     assert "dataset_id" not in conversation.to_dict()
 
 
@@ -435,7 +445,10 @@ def test_conversation_to_dict():
     assert result["demo_output"]["metadata"] == {"intent": "greeting"}
     assert "test-tag" in result["tags"]
     assert result["checks"][0]["identifier"] == "correctness"
-    assert result["checks"][0]["params"] == {"reference": "Hello world"}
+    assert result["checks"][0]["params"] == {
+        "reference": "Hello world",
+        "type": "correctness",
+    }
     assert "dataset_id" not in result
     assert "comments" not in result
 


### PR DESCRIPTION
This PR enables to properly create/update a chat test case (conversation) using the checks from another conversation.

For example:

```
conversation_01 = hub.conversations.retrieve(conversation_id)

# List of checks containing built-in and custom
conversation_01.checks 
```

```
# Before it was returning an error due to missing param 'type'
hub.conversations.create(...., checks=conversation_01.checks)
```