### PR TITLE
fix: update EvaluationEntry to use `evaluation_id` instead of `evaluation_run_id`

### DIFF
--- a/src/giskard_hub/data/evaluation.py
+++ b/src/giskard_hub/data/evaluation.py
@@ -196,7 +196,7 @@ class EvaluationEntry(Entity):
         output = data.get("output")
         data["model_output"] = ModelOutput.from_dict(output) if output else None
 
-        run_id = data.get("evaluation_run_id") or data.get("execution_id")
+        run_id = data.get("evaluation_id")
         if run_id:
             data["run_id"] = run_id
 


### PR DESCRIPTION
The `evaluation_run_id` field is deprecated in `Evaluations` resource, now it should use `evaluation_id`