### PR TITLE
ci: harden workflows and relax release version input

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - dev
   pull_request:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Tag to be created, in the form X.Y.Z"
+        description: "Tag to be created (e.g., 1.2.3 or 2.0.0b4)"
         required: true
         type: string
 
@@ -12,6 +12,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate version input
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="${{ inputs.version }}"
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.+-]*$ ]]; then
+            echo "Invalid version: '$VERSION'. Expected X.Y.Z optionally followed by letters/digits (e.g., 2.0.0b4)" >&2
+            exit 1
+          fi
+          echo "VERSION=$VERSION" >> "$GITHUB_ENV"
       - name: Check if organization member
         id: is_organization_member
         uses: JamesSingleton/is-organization-member@311430b0670cdec4036e721029b78018236a0b74 # 1.1.0
@@ -40,7 +50,9 @@ jobs:
           python-version: "3.13"
 
       - name: Change version
-        run: uv version ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          uv version "${VERSION}"
 
       - name: Build release candidate wheel
         run: uv build
@@ -54,13 +66,14 @@ jobs:
         run: |
           git add pyproject.toml uv.lock
           git fetch --quiet --tags
-          git commit -m "v${{ inputs.version }}" --allow-empty
-          git tag v${{ inputs.version }}
+          git commit -m "v${VERSION}" --allow-empty
+          git tag "v${VERSION}"
 
       - name: Push to main and tags
         run: |
+          set -euo pipefail
           git push origin main
-          git push origin v${{ inputs.version }}
+          git push origin "v${VERSION}"
 
       - name: Create Github Release
         id: github-release

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -26,8 +26,15 @@ jobs:
 
       - name: Merge latest code
         run: |
+          set -euo pipefail
+          REF_NAME="${{ github.ref_name }}"
+          # allow only safe ref name characters (alnum, /, ., -, _)
+          if [[ ! "$REF_NAME" =~ ^[A-Za-z0-9_./-]{1,200}$ ]]; then
+            echo "Invalid ref name: '$REF_NAME'" >&2
+            exit 1
+          fi
           git fetch --prune
-          git merge origin/${{ github.ref_name }}
+          git merge "origin/${REF_NAME}"
 
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@b75a909f75acd358c2196fb9a5f1299a9a8868a4 # v6.7.0


### PR DESCRIPTION
- Add read-only permissions to CI workflow
- Validate release version with simple X.Y.Z[alnum/._+-]* pattern (allows 2.0.0b4)
- Use VERSION env var for uv version, commit, tag, and push with set -euo
- Sanitize ref name in docs updater before merging to avoid unsafe refs