### PR TITLE
chore: use GitHub App for release workflow and migrate to rulesets

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,8 +18,8 @@ jobs:
   release:
     name: Build and publish release
     runs-on: ubuntu-latest
+    environment: release
     permissions:
-      contents: write # push commits/tags and create GitHub Releases
       id-token: write # OIDC token for PyPI trusted publishing
     env:
       VERSION: ${{ inputs.version }}
@@ -33,19 +33,20 @@ jobs:
             exit 1
           fi
       - name: Check if organization member
-        id: is_organization_member
-        uses: JamesSingleton/is-organization-member@311430b0670cdec4036e721029b78018236a0b74 # 1.1.0
-        with:
-          organization: Giskard-AI
-          username: ${{ github.actor }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Interrupt job
-        if: ${{ steps.is_organization_member.outputs.result == 'false' }}
-        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          echo "Job failed due to user not being a member of Giskard-AI organization and the 'safe for build' label not being set on the PR"
-          exit 1
+          if ! gh api orgs/Giskard-AI/members/${{ github.actor }} --silent 2>/dev/null; then
+            echo "Job failed due to user not being a member of Giskard-AI organization" >&2
+            exit 1
+          fi
+
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -56,11 +57,11 @@ jobs:
 
       - name: Configure git
         run: |
-          git config --global user.name 'BotReleaser'
-          git config --global user.email 'bot.releaser@users.noreply.github.com'
-          git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/Giskard-AI/giskard-hub.git"
+          git config --global user.name 'giskard-hub-release-bot[bot]'
+          git config --global user.email '3192176+giskard-hub-release-bot[bot]@users.noreply.github.com'
+          git remote set-url origin "https://x-access-token:${APP_TOKEN}@github.com/Giskard-AI/giskard-hub.git"
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@61cb8a9741eeb8a550a1b8544337180c0fc8476b # v7.2.0
@@ -91,7 +92,7 @@ jobs:
 
       - name: Create Github Release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           gh release create "v${VERSION}" \

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -35,8 +35,9 @@ jobs:
       - name: Check if organization member
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
         run: |
-          if ! gh api orgs/Giskard-AI/members/${{ github.actor }} --silent 2>/dev/null; then
+          if ! gh api "orgs/Giskard-AI/members/${ACTOR}" --silent 2>/dev/null; then
             echo "Job failed due to user not being a member of Giskard-AI organization" >&2
             exit 1
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 evaluations/
 test-folder/
+*.pem
 
 .history
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
## Summary

- Replace `RELEASE_PAT_TOKEN` with a dedicated GitHub App (`giskard-hub-release-bot`) for the release workflow
- App credentials (`RELEASE_APP_ID`, `RELEASE_APP_PRIVATE_KEY`) scoped to the `release` environment
- Replace `JamesSingleton/is-organization-member` third-party action with a `gh api` call
- Add `environment: release` to the job for environment-scoped secrets/variables
- Migrated classic branch protection on `main` to a Ruleset with the app as a bypass actor

### Infrastructure changes (already applied)

- Created `release` GitHub Environment with app credentials
- Created "Protect main branch" ruleset (replaces classic branch protection):
  - Same rules: 1 review, 9 status checks, linear history, no deletion/force-push
  - `giskard-hub-release-bot` added as bypass actor
- Deleted classic branch protection on `main`

## Before merging

1. Configure PyPI trusted publisher at https://pypi.org/manage/project/giskard-hub/settings/publishing/
   - Owner: `Giskard-AI`, Repository: `giskard-hub`, Workflow: `create-release.yml`

## Test plan

- [ ] CI passes (pre_checks + test matrix)
- [ ] Verify release workflow can push to main via the app token (test release)
- [ ] Verify PyPI trusted publishing works on first release

Made with [Cursor](https://cursor.com)